### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+    "name": "Furrcamp Devcontainer",
+    "image": "mcr.microsoft.com/vscode/devcontainers/base:ubuntu",
+    "postCreateCommand": "pip install -r requirements.txt && wget https://simonrepp.com/faircamp/packages/faircamp_1.3.0-1+deb12_amd64.deb && sudo gdebi -n faircamp_1.3.0-1+deb12_amd64.deb"
+}

--- a/README.md
+++ b/README.md
@@ -2,3 +2,12 @@
 
 ## Dev
 
+## Using the Devcontainer
+
+To use the devcontainer, follow these steps:
+
+1. Install Visual Studio Code.
+2. Install the Remote - Containers extension.
+3. Open the project in Visual Studio Code.
+4. When prompted, reopen the project in the container.
+5. The devcontainer will automatically install the dependencies from `requirements.txt` and `faircamp`.


### PR DESCRIPTION
Add devcontainer configuration and update README.md

* **Devcontainer Configuration**
  - Create `.devcontainer/devcontainer.json` to define the devcontainer configuration.
  - Set the image to `mcr.microsoft.com/vscode/devcontainers/base:ubuntu`.
  - Add a postCreateCommand to install dependencies from `requirements.txt` and `faircamp`.

* **README.md**
  - Add a section to explain how to use the devcontainer.
  - Provide steps to install Visual Studio Code, the Remote - Containers extension, and how to open the project in the container.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/constructions-incongrues/furrcamp/pull/1?shareId=1eafebfe-c7b1-4e8a-861a-ec55e32999c7).